### PR TITLE
ci: Add a job to force the use of upper bounds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: ${{ matrix.os }} ghc-${{ matrix.ghc }} ${{ matrix.configure-flags }}
+    name: ${{ matrix.os }} ghc-${{ matrix.ghc }} ${{ matrix.cache-key-prefix }}
     strategy:
       matrix:
         cache-key-prefix: [""]  # see `include` below
@@ -12,6 +12,7 @@ jobs:
         ghc: [9.4.7, 9.6.7, 9.8.4, 9.10.1, 9.12.2]
         haddock: [true]  # see `include` below
         os: [ubuntu-24.04]
+        pre-hook: [""]  # see `include` below
         include:
         # Include a single build (with latest Linux OS and oldest GHC version)
         # using `--prefer-oldest` to verify that we still build against the
@@ -21,6 +22,27 @@ jobs:
           ghc: 9.4.7
           haddock: false
           os: ubuntu-24.04
+        # Include a single build (with latest Linux OS and latest GHC version)
+        # using `cabal-force-upper-bounds` to verify that we actually build
+        # against the upper bounds in the Cabal `build-depends`.
+        - cache-key-prefix: upper-bounds
+          ghc: 9.12.2
+          haddock: false
+          os: ubuntu-24.04
+          pre-hook: |
+            curl \
+              --fail \
+              --location \
+              --proto '=https' \
+              --show-error \
+              --silent \
+              --tlsv1.2 \
+              https://github.com/nomeata/cabal-force-upper-bound/releases/download/0.1/cabal-force-upper-bound.linux.gz | \
+              gunzip > \
+              /usr/local/bin/cabal-force-upper-bound
+            chmod +x /usr/local/bin/cabal-force-upper-bound
+            echo 'packages: .' > cabal.project
+            cabal-force-upper-bound --cabal-project *.cabal >> cabal.project
       fail-fast: false
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
@@ -31,3 +53,4 @@ jobs:
       haddock: ${{ matrix.haddock }}
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
+      pre-hook: ${{ matrix.pre-hook }}


### PR DESCRIPTION
See [the upstream README](https://github.com/nomeata/cabal-force-upper-bound) (and the linked Cabal issue) for motivation.

Here's a CI build where it successfully prevented me from adding `containers < 0.9` (0.8 does not yet exist): https://github.com/GaloisInc/oughta/actions/runs/14621422504/job/41022282594